### PR TITLE
fix: explicitly declare `actionsExecuting` return type

### DIFF
--- a/src/lib/actions-executing.selector.ts
+++ b/src/lib/actions-executing.selector.ts
@@ -3,7 +3,7 @@ import { ActionsExecutingState, ActionsExecutingStateModel } from './actions-exe
 
 export type ActionsExecuting = { [action: string]: number } | null;
 
-export function actionsExecuting(actionTypes: ActionType[]) {
+export function actionsExecuting(actionTypes: ActionType[]): (state: ActionsExecutingStateModel) => ActionsExecuting {
     return createSelector(
         [ActionsExecutingState],
         (state: ActionsExecutingStateModel): ActionsExecuting => {


### PR DESCRIPTION
If the return type if the `actionsExecuting` selector is **not** explicitly defined, the typescript compiler produces the following signature:

```typescript
export declare function actionsExecuting(actionTypes: ActionType[]): (state: ActionsExecutingStateModel) => {
    [action: string]: number;
};
```
This produces an error when an application is compiled with the typescript "strictNullChecks" flag set to true.

![image](https://user-images.githubusercontent.com/9112303/78066863-01c1fb00-7396-11ea-9b17-9d3d4d7d7a6a.png)

With this fix, the compiler produces the following signature and every works:

```typescript
export declare function actionsExecuting(actionTypes: ActionType[]): (state: ActionsExecutingStateModel) => ActionsExecuting;
```




