### PR TITLE
Fixed potential errors if the state is undefined

### DIFF
--- a/src/lib/actions-executed.state.ts
+++ b/src/lib/actions-executed.state.ts
@@ -26,8 +26,7 @@ export class ActionsExecutedState implements NgxsOnInit, OnDestroy {
                         return;
                     }
 
-                    var state = getState();
-                    let count = state ? state[actionType] || 0 : 0;
+                    let count = getState()?.[actionType] ?? 0;
 
                     if (actionContext.status !== ActionStatus.Dispatched) {
                         count++;

--- a/src/lib/actions-executed.state.ts
+++ b/src/lib/actions-executed.state.ts
@@ -26,7 +26,8 @@ export class ActionsExecutedState implements NgxsOnInit, OnDestroy {
                         return;
                     }
 
-                    let count = getState()[actionType] || 0;
+                    var state = getState();
+                    let count = state ? state[actionType] || 0 : 0;
 
                     if (actionContext.status !== ActionStatus.Dispatched) {
                         count++;

--- a/src/lib/actions-executed.state.ts
+++ b/src/lib/actions-executed.state.ts
@@ -26,7 +26,7 @@ export class ActionsExecutedState implements NgxsOnInit, OnDestroy {
                         return;
                     }
 
-                    let count = getState()?.[actionType] ?? 0;
+                    let count = getState()?.[actionType] || 0;
 
                     if (actionContext.status !== ActionStatus.Dispatched) {
                         count++;

--- a/src/lib/actions-executing.state.ts
+++ b/src/lib/actions-executing.state.ts
@@ -26,8 +26,7 @@ export class ActionsExecutingState implements NgxsOnInit, OnDestroy {
                         return;
                     }
 
-                    var state = getState();
-                    let count = state ? state[actionType] || 0 : 0;
+                    let count = getState()?.[actionType] ?? 0;
 
                     if (actionContext.status === ActionStatus.Dispatched) {
                         count++;

--- a/src/lib/actions-executing.state.ts
+++ b/src/lib/actions-executing.state.ts
@@ -26,7 +26,7 @@ export class ActionsExecutingState implements NgxsOnInit, OnDestroy {
                         return;
                     }
 
-                    let count = getState()?.[actionType] ?? 0;
+                    let count = getState()?.[actionType] || 0;
 
                     if (actionContext.status === ActionStatus.Dispatched) {
                         count++;

--- a/src/lib/actions-executing.state.ts
+++ b/src/lib/actions-executing.state.ts
@@ -26,7 +26,8 @@ export class ActionsExecutingState implements NgxsOnInit, OnDestroy {
                         return;
                     }
 
-                    let count = getState()[actionType] || 0;
+                    var state = getState();
+                    let count = state ? state[actionType] || 0 : 0;
 
                     if (actionContext.status === ActionStatus.Dispatched) {
                         count++;


### PR DESCRIPTION
This caused e.g. errors when the StateClear actions of ngxs-reset-plugin is used.
Fixes #16, where the state is completely removed.
By ignoring undefined and treating it as count 0, it will continue to work for such cases.